### PR TITLE
[DEFECT 3] Fix step icons not updating during workflow progression v2.5.41

### DIFF
--- a/v2/main.go
+++ b/v2/main.go
@@ -211,7 +211,7 @@ func main() {
 	}
 
 	// Start the server
-	log.Println("[INFO] Starting Mallon Legal Server v2.5.40 on :8080")
+	log.Println("[INFO] Starting Mallon Legal Server v2.5.41 on :8080")
 	log.Printf("[INFO] Features: Dynamic document processing (Task 8), document editing, Go SSR + HTMX, Enhanced Session Navigation (Defect 1C)")
 	log.Printf("[INFO] Templates directory: /Users/corelogic/satori-dev/clients/proj-mallon/v2/templates")
 	log.Printf("[INFO] Test iCloud directory: /Users/corelogic/satori-dev/clients/proj-mallon/test_icloud")

--- a/v2/templates/_progress_steps_content.gohtml
+++ b/v2/templates/_progress_steps_content.gohtml
@@ -1,8 +1,8 @@
 {{define "_progress_steps_content.gohtml"}}
 <div class="flex items-center justify-between">
     <div class="flex items-center {{if ge .CurrentStep 0}}text-blue-600{{else}}text-gray-400{{end}}">
-        <button {{if ge .SessionState.CurrentStep 0}}hx-get="/ui/step/0" hx-target="#step-content" hx-swap="innerHTML"{{end}} 
-                class="flex items-center {{if ge .SessionState.CurrentStep 0}}cursor-pointer hover:bg-blue-50 rounded-lg p-2 -m-2{{else}}cursor-not-allowed{{end}}">
+        <button hx-get="/ui/step/0" hx-target="#step-content" hx-swap="innerHTML"
+                class="flex items-center cursor-pointer hover:bg-blue-50 rounded-lg p-2 -m-2">
             <div class="rounded-full h-8 w-8 flex items-center justify-center border-2 font-bold {{if eq .CurrentStep 0}}bg-blue-600 text-white border-blue-600{{else if gt .CurrentStep 0}}border-blue-600 bg-white text-blue-600{{else}}border-gray-400 bg-white text-gray-400{{end}}">
                 {{if gt .CurrentStep 0}}✓{{else}}0{{end}}
             </div>
@@ -11,8 +11,8 @@
     </div>
     <div class="flex-1 h-1 mx-4 {{if ge .CurrentStep 1}}bg-blue-600{{else}}bg-gray-200{{end}}"></div>
     <div class="flex items-center {{if ge .CurrentStep 1}}text-blue-600{{else}}text-gray-400{{end}}">
-        <button {{if and (ge .SessionState.CurrentStep 1) .SessionState.SelectedCaseFolder}}hx-get="/ui/step/1" hx-target="#step-content" hx-swap="innerHTML"{{end}} 
-                class="flex items-center {{if and (ge .SessionState.CurrentStep 1) .SessionState.SelectedCaseFolder}}cursor-pointer hover:bg-blue-50 rounded-lg p-2 -m-2{{else}}cursor-not-allowed{{end}}">
+        <button {{if and .SelectedCaseFolder (ge .CurrentStep 1)}}hx-get="/ui/step/1" hx-target="#step-content" hx-swap="innerHTML"{{end}} 
+                class="flex items-center {{if and .SelectedCaseFolder (ge .CurrentStep 1)}}cursor-pointer hover:bg-blue-50 rounded-lg p-2 -m-2{{else}}cursor-not-allowed{{end}}">
             <div class="rounded-full h-8 w-8 flex items-center justify-center border-2 font-bold {{if eq .CurrentStep 1}}bg-blue-600 text-white border-blue-600{{else if gt .CurrentStep 1}}border-blue-600 bg-white text-blue-600{{else}}border-gray-400 bg-white text-gray-400{{end}}">
                 {{if gt .CurrentStep 1}}✓{{else}}1{{end}}
             </div>
@@ -21,8 +21,8 @@
     </div>
     <div class="flex-1 h-1 mx-4 {{if ge .CurrentStep 2}}bg-blue-600{{else}}bg-gray-200{{end}}"></div>
     <div class="flex items-center {{if ge .CurrentStep 2}}text-blue-600{{else}}text-gray-400{{end}}">
-        <button {{if and (ge .SessionState.CurrentStep 2) .SessionState.SelectedDocuments}}hx-get="/ui/step/2" hx-target="#step-content" hx-swap="innerHTML"{{end}} 
-                class="flex items-center {{if and (ge .SessionState.CurrentStep 2) .SessionState.SelectedDocuments}}cursor-pointer hover:bg-blue-50 rounded-lg p-2 -m-2{{else}}cursor-not-allowed{{end}}">
+        <button {{if and .SelectedDocuments (ge .CurrentStep 2)}}hx-get="/ui/step/2" hx-target="#step-content" hx-swap="innerHTML"{{end}} 
+                class="flex items-center {{if and .SelectedDocuments (ge .CurrentStep 2)}}cursor-pointer hover:bg-blue-50 rounded-lg p-2 -m-2{{else}}cursor-not-allowed{{end}}">
             <div class="rounded-full h-8 w-8 flex items-center justify-center border-2 font-bold {{if eq .CurrentStep 2}}bg-blue-600 text-white border-blue-600{{else if gt .CurrentStep 2}}border-blue-600 bg-white text-blue-600{{else}}border-gray-400 bg-white text-gray-400{{end}}">
                 {{if gt .CurrentStep 2}}✓{{else}}2{{end}}
             </div>
@@ -31,8 +31,8 @@
     </div>
     <div class="flex-1 h-1 mx-4 {{if ge .CurrentStep 3}}bg-blue-600{{else}}bg-gray-200{{end}}"></div>
     <div class="flex items-center {{if ge .CurrentStep 3}}text-blue-600{{else}}text-gray-400{{end}}">
-        <button {{if and (ge .SessionState.CurrentStep 3) .SessionState.SelectedTemplate}}hx-get="/ui/step/3" hx-target="#step-content" hx-swap="innerHTML"{{end}} 
-                class="flex items-center {{if and (ge .SessionState.CurrentStep 3) .SessionState.SelectedTemplate}}cursor-pointer hover:bg-blue-50 rounded-lg p-2 -m-2{{else}}cursor-not-allowed{{end}}">
+        <button {{if and .SelectedTemplate (ge .CurrentStep 3)}}hx-get="/ui/step/3" hx-target="#step-content" hx-swap="innerHTML"{{end}} 
+                class="flex items-center {{if and .SelectedTemplate (ge .CurrentStep 3)}}cursor-pointer hover:bg-blue-50 rounded-lg p-2 -m-2{{else}}cursor-not-allowed{{end}}">
             <div class="rounded-full h-8 w-8 flex items-center justify-center border-2 font-bold {{if eq .CurrentStep 3}}bg-blue-600 text-white border-blue-600{{else if gt .CurrentStep 3}}border-blue-600 bg-white text-blue-600{{else}}border-gray-400 bg-white text-gray-400{{end}}">
                 {{if gt .CurrentStep 3}}✓{{else}}3{{end}}
             </div>
@@ -41,8 +41,8 @@
     </div>
     <div class="flex-1 h-1 mx-4 {{if ge .CurrentStep 4}}bg-blue-600{{else}}bg-gray-200{{end}}"></div>
     <div class="flex items-center {{if ge .CurrentStep 4}}text-blue-600{{else}}text-gray-400{{end}}">
-        <button {{if ge .SessionState.CurrentStep 4}}hx-get="/ui/step/4" hx-target="#step-content" hx-swap="innerHTML"{{end}} 
-                class="flex items-center {{if ge .SessionState.CurrentStep 4}}cursor-pointer hover:bg-blue-50 rounded-lg p-2 -m-2{{else}}cursor-not-allowed{{end}}">
+        <button {{if ge .CurrentStep 4}}hx-get="/ui/step/4" hx-target="#step-content" hx-swap="innerHTML"{{end}} 
+                class="flex items-center {{if ge .CurrentStep 4}}cursor-pointer hover:bg-blue-50 rounded-lg p-2 -m-2{{else}}cursor-not-allowed{{end}}">
             <div class="rounded-full h-8 w-8 flex items-center justify-center border-2 font-bold {{if eq .CurrentStep 4}}bg-blue-600 text-white border-blue-600{{else if gt .CurrentStep 4}}border-blue-600 bg-white text-blue-600{{else}}border-gray-400 bg-white text-gray-400{{end}}">
                 {{if gt .CurrentStep 4}}✓{{else}}4{{end}}
             </div>
@@ -51,8 +51,8 @@
     </div>
     <div class="flex-1 h-1 mx-4 {{if ge .CurrentStep 5}}bg-blue-600{{else}}bg-gray-200{{end}}"></div>
     <div class="flex items-center {{if ge .CurrentStep 5}}text-blue-600{{else}}text-gray-400{{end}}">
-        <button {{if ge .SessionState.CurrentStep 5}}hx-get="/ui/step/5" hx-target="#step-content" hx-swap="innerHTML"{{end}} 
-                class="flex items-center {{if ge .SessionState.CurrentStep 5}}cursor-pointer hover:bg-blue-50 rounded-lg p-2 -m-2{{else}}cursor-not-allowed{{end}}">
+        <button {{if ge .CurrentStep 5}}hx-get="/ui/step/5" hx-target="#step-content" hx-swap="innerHTML"{{end}} 
+                class="flex items-center {{if ge .CurrentStep 5}}cursor-pointer hover:bg-blue-50 rounded-lg p-2 -m-2{{else}}cursor-not-allowed{{end}}">
             <div class="rounded-full h-8 w-8 flex items-center justify-center border-2 font-bold {{if eq .CurrentStep 5}}bg-blue-600 text-white border-blue-600{{else if gt .CurrentStep 5}}border-blue-600 bg-white text-blue-600{{else}}border-gray-400 bg-white text-gray-400{{end}}">
                 {{if gt .CurrentStep 5}}✓{{else}}5{{end}}
             </div>

--- a/v2/templates/_step_wrapper.gohtml
+++ b/v2/templates/_step_wrapper.gohtml
@@ -1,5 +1,10 @@
 {{define "_step_wrapper.gohtml"}}
-<!-- Step Content Only - Removing OOB update temporarily for debugging -->
+<!-- Progress Steps Update via OOB -->
+<div hx-swap-oob="true" id="progress-steps">
+    {{template "_progress_steps_content.gohtml" .}}
+</div>
+
+<!-- Step Content -->
 {{if eq .CurrentStep 0}}
     {{template "_step0_case_setup.gohtml" .}}
 {{else if eq .CurrentStep 1}}

--- a/v2/templates/index.gohtml
+++ b/v2/templates/index.gohtml
@@ -13,7 +13,7 @@
         <!-- Header -->
         <header class="mb-8">
             <div class="flex justify-between items-center">
-                <h1 class="text-3xl font-bold text-gray-800">Legal Document Automation <span class="text-sm font-normal text-gray-500">v2.5.40</span></h1>
+                <h1 class="text-3xl font-bold text-gray-800">Legal Document Automation <span class="text-sm font-normal text-gray-500">v2.5.41</span></h1>
                 <div class="flex items-center space-x-4">
                     <!-- iCloud Status -->
                     <div class="flex items-center space-x-2">


### PR DESCRIPTION
## Summary
Restore progress step indicator functionality that was broken after template fixes. Step icons now properly update as users progress through the workflow and allow navigation between completed steps.

## Root Cause  
The out-of-band (OOB) HTMX update for progress steps was removed when fixing 500 errors, causing step indicators to remain static throughout the workflow.

## Changes Made
• **Restored OOB Progress Update**: Re-added `hx-swap-oob="true"` in `_step_wrapper.gohtml`
• **Fixed Data References**: Updated `_progress_steps_content.gohtml` to use correct data fields
• **Enhanced Navigation**: Simplified prerequisite checks and navigation logic
• **Improved Reliability**: Better template structure to prevent 500 errors

## Features Fixed
✅ Step icons update as user progresses through workflow  
✅ Current step highlighted in blue with white text  
✅ Completed steps show checkmarks and remain clickable  
✅ Future steps disabled until prerequisites met  
✅ Proper visual feedback for all step states (active, completed, disabled)  

## GitHub Issue
Fixes #8 - Step icons are no longer active

## Version Update
**v2.5.40 → v2.5.41**
- Server startup log updated
- Template masthead updated

## Test Plan
- [ ] Progress through workflow steps 0-3
- [ ] Verify step icons update correctly at each transition
- [ ] Test navigation between completed steps works
- [ ] Confirm visual states display properly (active, completed, disabled)
- [ ] Ensure no regression in step content loading
- [ ] Verify OOB updates work without 500 errors

## Technical Details
The fix restores the HTMX out-of-band swap mechanism that updates the progress indicator independently of the main step content, ensuring users always see their current position in the workflow.

🤖 Generated with [Claude Code](https://claude.ai/code)